### PR TITLE
Update terraform's required version with ~>

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -20,5 +20,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.1"
+  required_version = "~> 1.0.1"
 }


### PR DESCRIPTION
Tutorial terraform.tf is not in line with explanation where it mentions use if ~> https://learn.hashicorp.com/tutorials/terraform/provider-versioning?in=terraform/certification-associate-tutorials.
Also, changing it to using ~> 1.1.0 produces error:
│ Error: Unsupported Terraform Core version
│
│   on terraform.tf line 23, in terraform:
│   23:   required_version = "~> 1.1.0"
│
│ This configuration does not support Terraform version 1.0.2. To proceed, either choose another supported
│ Terraform version or update this version constraint. Version constraints are normally set for good reason,
│ so updating the constraint may lead to other errors or unexpected behavior.